### PR TITLE
enhance(version): adds version flag in blobfuse csi file driver

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -987,6 +987,7 @@
     "k8s.io/kubernetes/pkg/cloudprovider/providers/azure",
     "k8s.io/kubernetes/pkg/util/mount",
     "k8s.io/kubernetes/pkg/volume/util",
+    "sigs.k8s.io/yaml",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/blobfuse/blobfuse.go
+++ b/pkg/blobfuse/blobfuse.go
@@ -29,8 +29,8 @@ import (
 )
 
 const (
-	driverName       = "blobfuse.csi.azure.com"
-	vendorVersion    = "v0.1.0-alpha"
+	// DriverName holds the name of the csi-driver
+	DriverName       = "blobfuse.csi.azure.com"
 	seperator        = "#"
 	volumeIDTemplate = "%s#%s#%s"
 	fileMode         = "file_mode"
@@ -51,23 +51,20 @@ type Driver struct {
 // NewDriver Creates a NewCSIDriver object. Assumes vendor version is equal to driver version &
 // does not support optional driver plugin info manifest field. Refer to CSI spec for more details.
 func NewDriver(nodeID string) *Driver {
-	if nodeID == "" {
-		klog.Fatalln("NodeID missing")
-		return nil
-	}
-
 	driver := Driver{}
-	driver.Name = driverName
-	driver.Version = vendorVersion
+	driver.Name = DriverName
+	driver.Version = driverVersion
 	driver.NodeID = nodeID
-
 	return &driver
 }
 
 // Run driver initialization
 func (d *Driver) Run(endpoint string) {
-	klog.Infof("Driver: %v ", driverName)
-	klog.Infof("Version: %s", vendorVersion)
+	versionMeta, err := GetVersionYAML()
+	if err != nil {
+		klog.Fatalf("%v", err)
+	}
+	klog.Infof("\nDRIVER INFORMATION:\n-------------------\n%s\n\nStreaming logs below:", versionMeta)
 
 	cloud, err := GetCloudProvider()
 	if err != nil {

--- a/pkg/blobfuse/version.go
+++ b/pkg/blobfuse/version.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blobfuse
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+// These are set during build time via -ldflags
+var (
+	driverVersion = "N/A"
+	gitCommit     = "N/A"
+	buildDate     = "N/A"
+)
+
+// VersionInfo holds the version information of the driver
+type VersionInfo struct {
+	DriverName    string `json:"Driver Name"`
+	DriverVersion string `json:"Driver Version"`
+	GitCommit     string `json:"Git Commit"`
+	BuildDate     string `json:"Build Date"`
+	GoVersion     string `json:"Go Version"`
+	Compiler      string `json:"Compiler"`
+	Platform      string `json:"Platform"`
+}
+
+// GetVersion returns the version information of the driver
+func GetVersion() VersionInfo {
+	return VersionInfo{
+		DriverName:    DriverName,
+		DriverVersion: driverVersion,
+		GitCommit:     gitCommit,
+		BuildDate:     buildDate,
+		GoVersion:     runtime.Version(),
+		Compiler:      runtime.Compiler,
+		Platform:      fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}
+
+// GetVersionYAML returns the version information of the driver
+// in YAML format
+func GetVersionYAML() (string, error) {
+	info := GetVersion()
+	marshalled, err := yaml.Marshal(&info)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(marshalled)), nil
+}

--- a/pkg/blobfuseplugin/main.go
+++ b/pkg/blobfuseplugin/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	"github.com/csi-driver/blobfuse-csi-driver/pkg/blobfuse"
@@ -31,12 +32,20 @@ func init() {
 var (
 	endpoint = flag.String("endpoint", "unix://tmp/csi.sock", "CSI endpoint")
 	nodeID   = flag.String("nodeid", "", "node id")
+	version  = flag.Bool("version", false, "Print the version and exit.")
 )
 
 func main() {
 	klog.InitFlags(nil)
 	flag.Parse()
-
+	if *version {
+		info, err := blobfuse.GetVersionYAML()
+		if err != nil {
+			klog.Fatalln(err)
+		}
+		fmt.Println(info)
+		os.Exit(0)
+	}
 	if *nodeID == "" {
 		klog.Error("--nodeid is a required parameter")
 		os.Exit(1)


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit adds version flag in blobfuse csi file driver.
Output of `--version` flag:
```
ashishranjan738@Ashish-PC:~/Project/go/src/github.com/csi-driver/blobfuse-csi-driver$ ./_output/blobfuseplugin --version
Build Date: "2019-04-24T02:41:27Z"
Compiler: gc
Driver Name: blobfuse.csi.azure.com
Driver Version: v0.1.0-alpha2
Git Commit: 3d525e3cf4a221d7adae2062d4c248aed00ee9d2
Go Version: go1.12.1
Platform: linux/amd64
```

Output of streaming logs:
```
ashishranjan738@Ashish-PC:~/Project/go/src/github.com/csi-driver/blobfuse-csi-driver$ ./_output/blobfuseplugin --nodeid 6
I0424 08:41:47.345529   23895 blobfuse.go:67] 
DRIVER INFORMATION:
-------------------
Build Date: "2019-04-24T02:41:27Z"
Compiler: gc
Driver Name: blobfuse.csi.azure.com
Driver Version: v0.1.0-alpha2
Git Commit: 3d525e3cf4a221d7adae2062d4c248aed00ee9d2
Go Version: go1.12.1
Platform: linux/amd64

Streaming logs below:
E0424 08:41:47.345583   23895 azure.go:39] Failed to load config from file: /etc/kubernetes/azure.json
F0424 08:41:47.345592   23895 blobfuse.go:71] failed to get Azure Cloud Provider
```
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/csi-driver/blobfuse-csi-driver/issues/26

**Special notes for your reviewer**:


**Release note**:
```
enhance(version): adds version flag in blobfuse csi file driver
```
